### PR TITLE
Add PHP 7.3 and 7.4 versions to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,4 @@ matrix:
       dist: bionic
 
 install: travis_retry composer install
+script: ./vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,22 @@
-install:
-  - composer install
 language: php
-php:
-  - '5.4'
-  - '5.5'
-  - '5.6'
-  - '7.0'
-  - '7.1'
-  - '7.2'
+
+matrix:
+  include:
+    - php: 5.4
+      dist: trusty
+    - php: 5.5
+      dist: trusty
+    - php: 5.6
+      dist: trusty
+    - php: 7.0
+      dist: trusty
+    - php: 7.1
+      dist: bionic
+    - php: 7.2
+      dist: bionic
+    - php: 7.3
+      dist: bionic
+    - php: 7.4
+      dist: bionic
+
+install: travis_retry composer install

--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,8 @@
         "exclude-from-classmap": [
             "/Tests/"
         ]
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8 || ^7.5"
     }
 }


### PR DESCRIPTION
This will ensure that this project is forward compatible with them.

The `.travis.yml` file needed to be rewritten [as some old versions of PHP are not available anymore in newer distributions of Linux](https://travis-ci.org/Shudrum/ArrayFinder/builds/631577843).